### PR TITLE
Remove PHP 8.x deprecation notices

### DIFF
--- a/WireMailSmtpAdaptor.php
+++ b/WireMailSmtpAdaptor.php
@@ -200,9 +200,9 @@ class hnsmtp {
 		$this->emailMessage->smtp_certificate             = $this->smtp_certificate;
 
 		// advanced SMTP Server Settings
-		$this->emailMessage->realm                        = $this->realm;
-		$this->emailMessage->workstation                  = $this->workstation;
-		$this->emailMessage->authentication_mechanism     = $this->authentication_mechanism;
+		$this->emailMessage->smtp_realm                        = $this->realm;
+		$this->emailMessage->smtp_workstation                  = $this->workstation;
+		$this->emailMessage->smtp_authentication_mechanism     = $this->authentication_mechanism;
 
 		// Debug on / off
 		$this->emailMessage->smtp_debug                   = $this->smtp_debug;

--- a/smtp_classes/email_message.php
+++ b/smtp_classes/email_message.php
@@ -672,7 +672,7 @@ class email_message_class
 		if(strlen($host)
 		&& $host[strlen($host)-1]=="-")
 			$host=substr($host,0,strlen($host)-1);
-		return($this->FormatHeader("Message-ID", "<".strftime("%Y%m%d%H%M%S", $seconds).substr($micros,1,5).".".preg_replace('/[^A-Za-z]/', '-', $local)."@".preg_replace('/[^.A-Za-z_-]/', '', $host).">"));
+		return($this->FormatHeader("Message-ID", "<".date("YmdHMS", $seconds).substr($micros,1,5).".".preg_replace('/[^A-Za-z]/', '-', $local)."@".preg_replace('/[^.A-Za-z_-]/', '', $host).">"));
 	}
 
 	Function SendMail($to, $subject, $body, $headers, $return_path)


### PR DESCRIPTION
Here is the PR to replace the `strftime()` call with a regular `date()` one and I also quickly had a look at the deprecation warnings described here https://github.com/horst-n/WireMailSmtp/issues/15#issuecomment-1401871083