### PR TITLE
Enforce sender in emails

### DIFF
--- a/WireMailSmtp.module
+++ b/WireMailSmtp.module
@@ -520,7 +520,10 @@ class WireMailSmtp extends WireMail implements Module, ConfigurableModule {
      *
      */
     public function from($email = '', $name = null) {
-        if(is_null($name)) list($email, $name) = $this->extractEmailAndName($email);
+        if ($this->force_sender == 1){
+           $email = '';
+        }
+        elseif(is_null($name)) list($email, $name) = $this->extractEmailAndName($email);
             if(empty($email)) {
                 $email = $this->sender_email;
                 $name = $this->sender_name;

--- a/WireMailSmtpConfig.php
+++ b/WireMailSmtpConfig.php
@@ -283,7 +283,7 @@ class WireMailSmtpConfig extends Wire {
                 $field->notes = $this->attentionMessage($siteconfig['sender_email']);
                 $field->attr('tabindex', '-1');
             }
-            $field->columnWidth = 50;
+            $field->columnWidth = 40;
             $field->icon = 'at';
             $fieldset->add($field);
 
@@ -296,8 +296,24 @@ class WireMailSmtpConfig extends Wire {
                 $field->notes = $this->attentionMessage($siteconfig['sender_name']);
                 $field->attr('tabindex', '-1');
             }
-            $field->columnWidth = 50;
+            $field->columnWidth = 40;
             $field->icon = 'user';
+            $fieldset->add($field);
+
+            // FORCE USERNAME AS SENDER
+            $field = $modules->get('InputfieldCheckbox');
+            $field->attr('name', 'force_sender');
+            $field->attr('id', 'force_sender');
+            $field->attr('value', 1);
+            $field->attr('checked', $data['force_sender'] ? 'checked' : '');
+            $field->columnWidth = 20;
+            $field->label = $this->_('Force SMTP User as sender');
+            $field->description = $this->_('Check if SMTP allows messages only from mailbox user. This will force From-field as set in this configuration.');
+            if(isset($siteconfig['force_sender'])) {
+                $field->notes = $this->attentionMessage($siteconfig['force_sender']);
+                $field->attr('tabindex', '-1');
+            }
+            $field->icon = 'user-circle-o';
             $fieldset->add($field);
 
             // SENDER REPLY EMAIL


### PR DESCRIPTION
Greetings!

My 2 cents: At least Outlook 365 accounts require that address in From-field must match with username. I've added a checkbox in config to override From-address to be the same as sender defined in configuration.

Regards
Eero J.