### PR TITLE
Updated for longer TLDs

### DIFF
--- a/smtp_classes/email_message.php
+++ b/smtp_classes/email_message.php
@@ -324,7 +324,7 @@ class email_message_class
 	var $line_break="\n";
 	var $line_length=76;
 	var $ruler="_";
-	var $email_address_pattern="([-!#\$%&'*+./0-9=?A-Z^_`a-z{|}~])+@([-!#\$%&'*+/0-9=?A-Z^_`a-z{|}~]+\\.)+[a-zA-Z]{2,6}";
+	var $email_address_pattern="([-!#\$%&'*+./0-9=?A-Z^_`a-z{|}~])+@([-!#\$%&'*+/0-9=?A-Z^_`a-z{|}~]+\\.)+[a-zA-Z]{2,24}";
 	var $bulk_mail=0;
 
 	/* Public variables */


### PR DESCRIPTION
The regex here was capping TLDs with a low length of up to 6 characters whereas the longest TLD in existence is 24 characters. I've suggested 24, but the longest theoretical at the moment appears to be 63 so maybe that's the correct number: https://stackoverflow.com/a/22038535

At the moment the module simply shortens addresses with longer TLDs like .solutions etc and caps them at 6 chars instead of erroring, so it becomes .soluti instead. Since I use this alongside Postmark it is actually quite helpful to see the message attempt, but I think it should maybe write to a log if stuff like this crops up to make it easier to spot - not sure what's best really.

Jason found the issue by the way so credit to him: https://processwire.com/talk/topic/5704-wiremailsmtp/?do=findComment&comment=237791