### PR TITLE
Fix PHP 8.5 deprecations

### DIFF
--- a/WireMailSmtpAdaptor.php
+++ b/WireMailSmtpAdaptor.php
@@ -153,7 +153,7 @@ class hnsmtp {
 				break;
 
 			case 'valid_recipients':
-			case 'extra_headers';
+            case 'extra_headers':
 				$this->$k = is_array($v) || is_string($v) ? (array)$v : array();
 				break;
 

--- a/smtp_classes/email_message.php
+++ b/smtp_classes/email_message.php
@@ -1811,7 +1811,7 @@ class email_message_class
 			return($this->error);
 		switch($this->body_parts)
 		{
-			case 0;
+            case 0:
 				$this->body=$part;
 				break;
 			case 1:

--- a/smtp_classes/email_message.php
+++ b/smtp_classes/email_message.php
@@ -901,10 +901,8 @@ class email_message_class
 						$body.=$block;
 					}
 					fclose($file);
-					if((GetType($size)=="integer"
-					&& strlen($body)>$size)
-					|| (function_exists("get_magic_quotes_runtime")
-					&& get_magic_quotes_runtime()))
+					if((is_int($size)
+					&& strlen($body)>$size))
 						$body=StripSlashes($body);
 					if(GetType($size)=="integer"
 					&& strlen($body)!=$size)

--- a/smtp_classes/smtp.php
+++ b/smtp_classes/smtp.php
@@ -996,8 +996,8 @@ class smtp_class
 			{
 				$timeout=($this->data_timeout ? $this->data_timeout : $this->timeout);
 				if($timeout
-				&& function_exists("socket_set_timeout"))
-					socket_set_timeout($this->connection,$timeout,0);
+				&& function_exists("stream_set_timeout"))
+					stream_set_timeout($this->connection, $timeout, 0);
 				if(strlen($this->socks_host_name))
 				{
 					if($this->debug)
@@ -1109,8 +1109,8 @@ class smtp_class
 					$this->OutputDebug('Connected to HTTP proxy host "'.$this->http_proxy_host_name.'".');
 				$timeout=($this->data_timeout ? $this->data_timeout : $this->timeout);
 				if($timeout
-				&& function_exists("socket_set_timeout"))
-					socket_set_timeout($this->connection,$timeout,0);
+				&& function_exists("stream_set_timeout"))
+                    stream_set_timeout($this->connection,$timeout,0);
 				if($this->PutLine('CONNECT '.$domain.':'.$port.' HTTP/1.0')
 				&& $this->PutLine('User-Agent: '.$this->user_agent)
 				&& $this->PutLine(''))
@@ -1462,8 +1462,8 @@ class smtp_class
 		}
 		$timeout=($this->data_timeout ? $this->data_timeout : $this->timeout);
 		if($timeout
-		&& function_exists("socket_set_timeout"))
-			socket_set_timeout($this->connection,$timeout,0);
+		&& function_exists("stream_set_timeout"))
+            stream_set_timeout($this->connection,$timeout,0);
 		if($this->debug)
 			$this->OutputDebug("Connected to SMTP server \"".$domain."\".");
 		if(!strcmp($localhost=$this->localhost,"")

--- a/smtp_classes/xoauth2_sasl_client.php
+++ b/smtp_classes/xoauth2_sasl_client.php
@@ -110,7 +110,7 @@ class xoauth2_sasl_client_class
 					}
 					elseif(strlen($oauth->access_token))
 					{
-						$now = gmstrftime('%Y-%m-%d %H:%M:%S', time());
+						$now = gmdate('Y-m-d H:i:s', time());
 						if(strcmp($now, $oauth->access_token_expiry) > 0)
 						{
 							error_log('The OAuth token has expired.');


### PR DESCRIPTION
This PR addresses several deprecation warnings and compatibility issues with newer PHP versions – see Issue #26.

- Fix case statements using a trailing `;` instead of `:`
- Remove `get_magic_quotes_runtime()` usage (deprecated since PHP 5.3, removed in PHP 7.0)
- Replace `socket_set_timeout()` with `stream_set_timeout() ` (deprecated since PHP 8.5)
- Replace `gmstrftime()` with `gmdate()` (deprecated since PHP 8.1)

The deprecation warnings in `NTLMResponse()` (`mcrypt_*` functions) are intentionally not addressed in this PR. That functionality has been broken since PHP 7.2, when the `mcrypt` extension was removed, and requires a separate refactoring effort.